### PR TITLE
Issue with incestuous iframe links.

### DIFF
--- a/understanding_statistics/index.html
+++ b/understanding_statistics/index.html
@@ -70,9 +70,10 @@
 <script type="text/javascript">
 	var a = '<iframe src="http://188.166.78.89:3838/shiny/';
 	var b = getParameterByName('app');
-	var c = '" width="100%" height="1200px"></iframe>'
+	var c = '" width="100%" height="1200px">';
+	var d = '<base target="_blank" /></iframe>';
 	if (b != '') {
-		document.write(a.concat(b, c));
+		document.write(a.concat(b, c, d));
 	} else {
 		document.write('Click one of the above links to see a visualization!')
 	}


### PR DESCRIPTION
The links that are given within the shiny apps at http://188.166.78.89:3838/shiny/ are not opening in a new tab.  I'm not super familiar with javascript, but I got this answer from http://stackoverflow.com/questions/29792908/html5-base-tag-inside-nested-iframes-is-ignored-by-ie11 and http://stackoverflow.com/questions/1037839/how-to-force-link-from-iframe-to-be-opened-in-the-parent-window.  Hope this helps.